### PR TITLE
ES6 iterators - enable ForOf for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## Fork Info
+
+This is fork of [linq-collections](https://github.com/isc30/linq-collections) library by [isc30](https://github.com/isc30). Only support for ES6 iterators were added. It allows direct usage of `ForOf`. Example:
+
+```
+const list = new List([1, 2, 3]);
+for (const item of list) {
+    console.log(item);
+}
+```
+
 # Linq-Collections: (IEnumerable, ...) + (List, Dictionary, ...)
 
 [![npm version](https://img.shields.io/npm/v/linq-collections.svg)](https://npmjs.org/package/linq-collections)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "linq-collections",
+  "name": "linq-collections-es6",
   "version": "1.0.255",
-  "description": "Linq-Collections (ES5): [IEnumerable, IQueryable, ...] + [List, Dictionary, Stack, ... + readonly]",
+  "description": "Linq-Collections (ES6): [IEnumerable, IQueryable, ...] + [List, Dictionary, Stack, ... + readonly]. Compatible with ES6 iterators.",
   "main": "./build/src/Linq.js",
   "files": [
     "build/src",
@@ -14,18 +14,15 @@
   "typings": "./build/src/Linq.d.ts",
   "types": "./build/src/Linq.d.ts",
   "author": {
-    "name": "Ivan Sanz",
-    "email": "ivansanzcarasa@gmail.com",
-    "url": "https://github.com/isc30"
-  },
-  "bugs": {
-    "url": "https://github.com/isc30/linq-collections/issues"
+    "name": "Martin Volek",
+    "email": "martin@vdolek.cz",
+    "url": "https://github.com/vdolek"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/isc30/linq-collections"
+    "url": "https://github.com/vdolek/linq-collections-es6"
   },
-  "homepage": "https://github.com/isc30/linq-collections#readme",
+  "homepage": "https://github.com/vdolek/linq-collections-es6#readme",
   "scripts": {
     "node-compile": "tsc",
     "web-tests-compile": "browserify ./test/TestSuite.ts -p [tsify] > linq-tests.web.js",

--- a/src/Collections.ts
+++ b/src/Collections.ts
@@ -39,6 +39,10 @@ export abstract class EnumerableCollection<TElement>
     public abstract asEnumerable(): IEnumerable<TElement>;
     public abstract toArray(): TElement[];
 
+    [Symbol.iterator](): Iterator<TElement> {
+        return this.asEnumerable()[Symbol.iterator]();
+    }
+
     public toList(): IList<TElement>
     {
         return new List<TElement>(this.toArray());

--- a/src/Enumerables.ts
+++ b/src/Enumerables.ts
@@ -181,16 +181,10 @@ export abstract class EnumerableBase<TElement, TOut> implements IEnumerable<TOut
     public abstract copy(): IEnumerable<TOut>;
     public abstract value(): TOut;
 
-    [Symbol.iterator](): Iterator<TOut> {
+    *[Symbol.iterator](): Iterator<TOut> {
         const iterator = this.copy();
-        return {
-            next(): IteratorResult<TOut> {
-                const next = iterator.next();
-                return {
-                    done: !next,
-                    value: next ? iterator.value() : <any>null
-                };
-            }
+        while (iterator.next()) {
+            yield iterator.value();
         }
     }
 

--- a/src/Enumerables.ts
+++ b/src/Enumerables.ts
@@ -25,6 +25,8 @@ export type IGrouping<TKey, TElement> = IKeyValue<TKey, IQueryable<TElement>>;
 
 export interface IQueryable<TOut>
 {
+    [Symbol.iterator](): Iterator<TOut>;
+
     copy(): IQueryable<TOut>;
 
     asEnumerable(): IEnumerable<TOut>;
@@ -178,6 +180,19 @@ export abstract class EnumerableBase<TElement, TOut> implements IEnumerable<TOut
 
     public abstract copy(): IEnumerable<TOut>;
     public abstract value(): TOut;
+
+    [Symbol.iterator](): Iterator<TOut> {
+        const iterator = this.copy();
+        return {
+            next(): IteratorResult<TOut> {
+                const next = iterator.next();
+                return {
+                    done: !next,
+                    value: next ? iterator.value() : <any>null
+                };
+            }
+        }
+    }
 
     public reset(): void
     {

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -1,10 +1,15 @@
 export namespace Test
 {
+    export function fail(): void
+    {
+        throw new Error("Assertion failed")
+    }
+
     export function isTrue(result: boolean): void
     {
         if (result !== true)
         {
-            throw new Error("Assertion failed");
+            fail();
         }
     }
 

--- a/test/unitary/Enumerable.test.ts
+++ b/test/unitary/Enumerable.test.ts
@@ -6,10 +6,60 @@ export namespace EnumerableUnitTest
 {
     export function run(): void
     {
+        describe("ForOf", forOf);
         it("FromSource", fromSource);
         it("Empty", empty);
         describe("Range", range);
         it("Repeat", repeat);
+    }
+
+    function forOf(): void
+    {
+        it("Empty enumerable forOf works", () => {
+            const e = Enumerable.fromSource([]);
+            for (const item of e) {
+                Test.fail();
+            }
+        });
+
+        it("Enumerable forOf works", () => {
+            const e = Enumerable.fromSource([2, 4, 6]);
+
+            const array = [];
+            for (const item of e) {
+                array.push(item);
+            }
+
+            Test.isArrayEqual([2, 4, 6], array);
+        });
+
+        it("Enumerable where forOf works", () => {
+            const e = Enumerable.fromSource([2, 4, 6]).where(x => x < 5);
+
+            const array = [];
+            for (const item of e) {
+                array.push(item);
+            }
+
+            Test.isArrayEqual([2, 4], array);
+        });
+
+        it("Enumerable multiple enumerations forOf works", () => {
+            const e = Enumerable.fromSource([2, 4, 6]).where(x => x < 5);
+
+            const array = [];
+            for (const item of e) {
+                array.push(item);
+            }
+
+            const array2 = [];
+            for (const item of e) {
+                array2.push(item);
+            }
+
+            Test.isArrayEqual([2, 4], array);
+            Test.isArrayEqual([2, 4], array2);
+        });
     }
 
     function fromSource(): void

--- a/test/unitary/List.test.ts
+++ b/test/unitary/List.test.ts
@@ -5,6 +5,7 @@ export namespace ListUnitTest
 {
     export function run(): void
     {
+        describe("ForOf", forOf);
         describe("AsArray", asArray);
         describe("AsReadOnly", asReadOnly);
         describe("Copy", copy);
@@ -20,6 +21,27 @@ export namespace ListUnitTest
         describe("Set", set);
         describe("IndexOf", indexOf);
         describe("Insert", insert);
+    }
+
+    function forOf(): void
+    {
+        it("Empty list forOf works", () => {
+            const e = new List([]);
+            for (const item of e) {
+                Test.fail();
+            }
+        });
+
+        it("List forOf works", () => {
+            const e = new List([2, 4, 6]);
+
+            const array = [];
+            for (const item of e) {
+                array.push(item);
+            }
+
+            Test.isArrayEqual([2, 4, 6], array);
+        });
     }
 
     function asArray(): void

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
         "strictFunctionTypes": true,
         "types": ["mocha"],
         "outDir": "build",
-        "strictPropertyInitialization": false
+        "strictPropertyInitialization": false,
+        "downlevelIteration": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
This PR implements ES6 iterators for all collections in the library. It enables using ForOf with collections without using `toArray()` method.

Example:

```typescript
const list = new List([1, 2, 3]);
for (const item of list) {
    console.log(item);
}
```

Besides that it allows using collections with `*ngFor` in Angular without using `toArray()` method.